### PR TITLE
v0.1.1 リリース

### DIFF
--- a/Editor/SerializeReferenceSelectorDrawer.cs
+++ b/Editor/SerializeReferenceSelectorDrawer.cs
@@ -13,7 +13,7 @@ namespace UnityEditor
 
         int m_CurrentTypeIndex;
         string[]? m_DisplayNameArray;
-        System.Type[]? m_InheritedTypes;
+        System.Type?[]? m_InheritedTypes;
         bool m_IsInitialized = false;
         string[]? m_TypeFullNameArray;
         #endregion

--- a/Editor/SerializeReferenceSelectorDrawer.cs
+++ b/Editor/SerializeReferenceSelectorDrawer.cs
@@ -57,16 +57,34 @@ namespace UnityEditor
 
             var propertyPaths = property.propertyPath.Split('.');
             var parentType = property.serializedObject.targetObject.GetType();
-            var fieldInfo = parentType.GetField(propertyPaths[0], k_BindingAttr);
-            var fieldType = fieldInfo.FieldType;
+            var currentType = parentType;
 
-            if (propertyPaths.Contains("Array"))
+            foreach (var path in propertyPaths)
             {
-                return fieldType.IsArray
-                    ? fieldType.GetElementType()
-                    : fieldType.GetGenericArguments()[0];
+                if (path == "Array")
+                {
+                    currentType = currentType.IsArray
+                        ? currentType.GetElementType()
+                        : currentType.GetGenericArguments()[0];
+                }
+                else
+                {
+                    var fieldInfo = currentType.GetField(path, k_BindingAttr);
+                    if (fieldInfo != null)
+                    {
+                        currentType = fieldInfo.FieldType;
+                    }
+                    else
+                    {
+                        var propertyInfo = currentType.GetProperty(path, k_BindingAttr);
+                        if (propertyInfo != null)
+                        {
+                            currentType = propertyInfo.PropertyType;
+                        }
+                    }
+                }
             }
-            return fieldType;
+            return currentType;
         }
 
         SerializeReferenceSelectorAttribute Attr => (SerializeReferenceSelectorAttribute)attribute;

--- a/Editor/SerializeReferenceSelectorDrawer.cs
+++ b/Editor/SerializeReferenceSelectorDrawer.cs
@@ -75,7 +75,7 @@ namespace UnityEditor
         {
             m_InheritedTypes = System.AppDomain.CurrentDomain.GetAssemblies()
                 .SelectMany(s => s.GetTypes())
-                .Where(p => baseType.IsAssignableFrom(p) && p.IsClass && (Attr.IsIncludeMono || !k_MonoBehaviourType.IsAssignableFrom(p)))
+                .Where(p => baseType.IsAssignableFrom(p) && p.IsClass && !p.IsAbstract && (Attr.IsIncludeMono || !k_MonoBehaviourType.IsAssignableFrom(p)))
                 .Prepend(null)
                 .ToArray();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp.seibe.unity.serialize-reference-selector",
-  "version": "0.1.0-pre",
+  "version": "0.1.1",
   "displayName": "SerializeReference Selector",
   "unity": "2020.2",
   "author": {


### PR DESCRIPTION
警告1件と不具合2件の修正

- nullable指定誤りの修正
- 抽象型を表示に含まないように
- 入れ子になったシリアライズドオブジェクトの型を正確に取得できない問題の修正